### PR TITLE
REQUIRE julia-0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
   email: false
 env:
   matrix: 
-    - JULIAVERSION="juliareleases" 
     - JULIAVERSION="julianightlies" 
 before_install:
   - sudo add-apt-repository ppa:staticfloat/julia-deps -y

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
+julia 0.3-
 JSON
 Lazy


### PR DESCRIPTION
I've come across several instances of users installing Juno using Julia 0.2.1 and then running into problems due to missing features present only in the pre-release. Is this all that's needed to avoid that problem?
