### PR TITLE
Julia v0.4 compatibility

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ Compose
 LNR
 JuliaParser
 Requires
+Compat

--- a/src/Jewel.jl
+++ b/src/Jewel.jl
@@ -1,6 +1,6 @@
 module Jewel
 
-using LNR, Lazy, Requires
+using LNR, Lazy, Requires, Compat
 
 include("base.jl")
 include("parse/parse.jl")

--- a/src/LightTable/display/objects.jl
+++ b/src/LightTable/display/objects.jl
@@ -121,7 +121,7 @@ displayinline(a::Vector, t = "Vector") =
 displayinline(s::Set) = displayinline(collect(s), "Set")
 
 displayinline(d::Dict) =
-  Collapsible(span(strong("Dictionary "), fade("$(eltype(d)[1]) → $(eltype(d)[2]), $(length(d))")),
+  Collapsible(span(strong("Dictionary "), fade("$(eltype(d).parameters[1]) → $(eltype(d).parameters[2]), $(length(d))")),
               HTML() do io
                 println(io, """<table class="array">""")
                 kv = collect(d)

--- a/src/LightTable/display/objects.jl
+++ b/src/LightTable/display/objects.jl
@@ -149,7 +149,7 @@ import Jewel: @require
     isempty(f) ? Collapsible(span(strong("DataFrame "), fade("Empty"))) :
       Collapsible(span(strong("DataFrame "), fade("($(join(names(f), ", "))), $(size(f,1))")),
                   Table("data-frame", vcat(map(s->HTML(string(s)), names(f))',
-                                           DataFrames.array(f))))
+                                           DataFrames.DataArray(f))))
 end
 
 # Colors

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -83,8 +83,8 @@ moduleusings(mod) = ccall(:jl_module_usings, Any, (Any,), mod)
 filtervalid(names) = @>> names map(string) filter(x->!ismatch(r"#", x))
 
 accessible(mod::Module) =
-  [names(mod, true, true),
-   map(names, moduleusings(mod))...,
+  [names(mod, true, true);
+   map(names, moduleusings(mod))...;
    builtins] |> unique |> filtervalid
 
 function qualifier(s)

--- a/src/module.jl
+++ b/src/module.jl
@@ -17,7 +17,7 @@ files(dir) =
   @>> dir readdir′ map!(f->joinpath(dir, f)) filter!(isfile′)
 
 dirs(dir) =
-  @>> dir readdir′ filter!(f->!beginswith(f, ".")) map!(f->joinpath(dir, f)) filter!(isdir′)
+  @>> dir readdir′ filter!(f->!@compat Base.startswith(f, ".")) map!(f->joinpath(dir, f)) filter!(isdir′)
 
 jl_files(dir::String) = @>> dir files filter!(f->endswith(f, ".jl"))
 

--- a/src/parse/scope.jl
+++ b/src/parse/scope.jl
@@ -131,7 +131,7 @@ function nextscope!(scopes, ts)
   elseif isidentifier(t) || isa(t, Vector{Symbol})
     if peektoken(ts) == '('
       nexttoken(ts)
-      push!(scopes, Scope(:call, join([t], ".")))
+      push!(scopes, Scope(:call, isa(t, Vector{Symbol}) ? join(collect(t), ".") : t ))
     end
   end
   return t


### PR DESCRIPTION
This PR reduces of amount noise in Juno console due to Jewel using v0.4-deprecated constructs. 
It also fixes the display of dictionaries and dataframes with NAs (for the latter there's already a patch #26).