### PR TITLE
div -> DOM.div to avoid ambiguity with Base.div

### DIFF
--- a/src/LightTable/display/objects.jl
+++ b/src/LightTable/display/objects.jl
@@ -175,7 +175,7 @@ end
 # Gadfly
 
 @require Gadfly begin
-  displayinline(p::Gadfly.Plot) = div(p, style = "background: white")
+  displayinline(p::Gadfly.Plot) = DOM.div(p, style = "background: white")
 end
 
 # PyPlot

--- a/src/LightTable/interaction/interaction.jl
+++ b/src/LightTable/interaction/interaction.jl
@@ -12,7 +12,7 @@ Result(id, value) = Result(id, value, Dict())
 
 displayinline(r::Result) =
   Collapsible(span(strong("Result "), fade(string(r.id))),
-              div([applydisplayinline(r.value), applydisplayinline(r.data)]))
+              DOM.div([applydisplayinline(r.value), applydisplayinline(r.data)]))
 
 const results = Dict{UUID,Result}()
 


### PR DESCRIPTION
This fixes support for Gadfly in 0.4.  